### PR TITLE
Early return to avoid target duplication in vanilla JS tutorial

### DIFF
--- a/extensions/custom-field/shopify.extension.toml
+++ b/extensions/custom-field/shopify.extension.toml
@@ -3,7 +3,7 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2023-10"
+api_version = "2024-07"
 
 [[extensions]]
 type = "ui_extension"

--- a/extensions/custom-field/src/Checkout.js
+++ b/extensions/custom-field/src/Checkout.js
@@ -26,7 +26,12 @@ export default extension("purchase.checkout.shipping-option-list.render-after", 
 // [END custom-field.define-metafield]
 
 function renderUI({ root, api, state }) {
-  const { applyMetafieldChange } = api;
+  const { applyMetafieldChange, target } = api;
+
+    // Guard against duplicate rendering of `shipping-option-list.render-after` UI extension for one-time purchase and subscription sections. This would cause an overwrite of the metafield value when calling `applyMetafieldsChange` from the duplicated section. Instead of guarding, another approach would be to namespace the metafield for one-time purchase and subscription.
+    if (target.current.groupType !== 'oneTimePurchase') {
+      return null;
+    }
 
   // In case this is a re-render, then remove all previous children
   for (const child of root.children) {


### PR DESCRIPTION
This PR edits the custom field vanilla JS example found [here](https://shopify.dev/docs/apps/build/checkout/custom/fields/add?extension=javascript) in the docs. It adds an early return when the `groupType` is different than `'oneTimePurchase'`. It is the vanilla JS equivalent of https://github.com/Shopify/example-checkout--custom-field--react/pull/12

The adjusted code can be tested on this dev prod store:
https://dan-acxp-ui-extensions.myshopify.com/
password: `advanced`
no commit SHA
By: adding OTP items (eg. hydrogen snowboard, liquid snowboard) as well as subscriptions (wax subscription, liquid snowboard subscription), and checking out with an address in Canada.

You should see only 1 checkbox and 1 text field (when the checkbox is checked), instead of 2 checkboxes with text fields that overwrite each other (previous experience).

| Checkout experience | Admin (you can ignore other metafields) |
| --- | --- |
| ![Screenshot 2024-06-07 at 2 35 43 PM](https://github.com/Shopify/example-checkout--custom-field--js/assets/6304841/620a9f1b-bafe-4c59-8e37-fb2f5fe7b05c) | ![Screenshot 2024-06-07 at 2 36 09 PM](https://github.com/Shopify/example-checkout--custom-field--js/assets/6304841/4bdf0309-5953-4cf0-80ad-731784806d5c) |


